### PR TITLE
EMAIL_USE_SSL in example.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ Finally, it is **necessary** to assign values to settings:
     EMAIL_PORT = email_config['EMAIL_PORT']
     EMAIL_BACKEND = email_config['EMAIL_BACKEND']
     EMAIL_USE_TLS = email_config['EMAIL_USE_TLS']
+    EMAIL_USE_SSL = email_config['EMAIL_USE_SSL']
 
 Alternatively, it is possible to use this less explicit shortcut:
 


### PR DESCRIPTION
`EMAIL_USE_TLS = False` doesn't make `EMAIL_USE_SSL=True`.

But, this is missing in the examples. So, I have added it.