### PR TITLE
Changes in EMAIL_USE_SSL and tests. 

### DIFF
--- a/dj_email_url.py
+++ b/dj_email_url.py
@@ -52,6 +52,7 @@ def parse(url):
     conf = {}
 
     url = urlparse.urlparse(url)
+    qs = urlparse.parse_qs(url.query)
 
     # Remove query strings
     path = url.path[1:]
@@ -74,16 +75,14 @@ def parse(url):
     else:
         conf['EMAIL_USE_TLS'] = False
 
-    if url.scheme == 'smtp':
-        qs = urlparse.parse_qs(url.query)
-        if 'ssl' in qs and qs['ssl']:
-            if qs['ssl'][0] in ('1', 'true', 'True'):
-                conf['EMAIL_USE_SSL'] = True
-                conf['EMAIL_USE_TLS'] = False
-        if 'tls' in qs and qs['tls']:
-            if qs['tls'][0] in ('1', 'true', 'True'):
-                conf['EMAIL_USE_SSL'] = False
-                conf['EMAIL_USE_TLS'] = True
+    if 'ssl' in qs and qs['ssl']:
+        if qs['ssl'][0] in ('1', 'true', 'True'):
+            conf['EMAIL_USE_SSL'] = True
+            conf['EMAIL_USE_TLS'] = False
+    elif 'tls' in qs and qs['tls']:
+        if qs['tls'][0] in ('1', 'true', 'True'):
+            conf['EMAIL_USE_SSL'] = False
+            conf['EMAIL_USE_TLS'] = True
     else:
         conf['EMAIL_USE_SSL'] = False
 

--- a/dj_email_url.py
+++ b/dj_email_url.py
@@ -84,5 +84,7 @@ def parse(url):
             if qs['tls'][0] in ('1', 'true', 'True'):
                 conf['EMAIL_USE_SSL'] = False
                 conf['EMAIL_USE_TLS'] = True
+    else:
+        conf['EMAIL_USE_SSL'] = False
 
     return conf

--- a/test_dj_email_url.py
+++ b/test_dj_email_url.py
@@ -58,6 +58,12 @@ class EmailTestSuite(unittest.TestCase):
         assert url['EMAIL_USE_SSL'] is True
         assert url['EMAIL_USE_TLS'] is False
 
+    def test_smtps_backend_with_ssl(self):
+        url = 'smtps://user@domain.com:pass@smtp.example.com:465/?ssl=True'
+        url = dj_email_url.parse(url)
+        assert url['EMAIL_USE_SSL'] is True
+        assert url['EMAIL_USE_TLS'] is False
+
     def test_smtp_backend_with_tls(self):
         url = 'smtp://user@domain.com:pass@smtp.example.com:587/?tls=True'
         url = dj_email_url.parse(url)

--- a/test_dj_email_url.py
+++ b/test_dj_email_url.py
@@ -8,7 +8,7 @@ import dj_email_url
 
 
 class EmailTestSuite(unittest.TestCase):
-    def test_smtp_parsing(self):
+    def test_smtps_parsing(self):
         url = 'smtps://user@domain.com:password@smtp.example.com:587'
         url = dj_email_url.parse(url)
 
@@ -19,6 +19,7 @@ class EmailTestSuite(unittest.TestCase):
         assert url['EMAIL_HOST_USER'] == 'user@domain.com'
         assert url['EMAIL_PORT'] == 587
         assert url['EMAIL_USE_TLS'] is True
+        assert url['EMAIL_USE_SSL'] is False
 
     def test_console_parsing(self):
         url = 'console://'
@@ -31,6 +32,7 @@ class EmailTestSuite(unittest.TestCase):
         assert url['EMAIL_HOST_USER'] is None
         assert url['EMAIL_PORT'] is None
         assert url['EMAIL_USE_TLS'] is False
+        assert url['EMAIL_USE_SSL'] is False
 
     def test_email_url(self):
         a = dj_email_url.config()
@@ -48,6 +50,7 @@ class EmailTestSuite(unittest.TestCase):
         assert url['EMAIL_HOST_USER'] == 'user@domain.com'
         assert url['EMAIL_PORT'] == 587
         assert url['EMAIL_USE_TLS'] is True
+        assert url['EMAIL_USE_SSL'] is False
 
     def test_smtp_backend_with_ssl(self):
         url = 'smtp://user@domain.com:pass@smtp.example.com:465/?ssl=True'


### PR DESCRIPTION
`KeyError: 'EMAIL_USE_SSL'` is the result when I try to add the 
`EMAIL_USE_SSL = email_config['EMAIL_USE_SSL']` to settings. So made the following changes.