### PR TITLE
Set default dict values

### DIFF
--- a/dj_email_url.py
+++ b/dj_email_url.py
@@ -65,6 +65,8 @@ def parse(url):
         'EMAIL_HOST_PASSWORD': unquote(url.password),
         'EMAIL_HOST': url.hostname,
         'EMAIL_PORT': url.port,
+        'EMAIL_USE_SSL': False,
+        'EMAIL_USE_TLS': False,
     })
 
     if url.scheme in SCHEMES:
@@ -72,8 +74,6 @@ def parse(url):
 
     if url.scheme == 'smtps':
         conf['EMAIL_USE_TLS'] = True
-    else:
-        conf['EMAIL_USE_TLS'] = False
 
     if 'ssl' in qs and qs['ssl']:
         if qs['ssl'][0] in ('1', 'true', 'True'):
@@ -83,7 +83,5 @@ def parse(url):
         if qs['tls'][0] in ('1', 'true', 'True'):
             conf['EMAIL_USE_SSL'] = False
             conf['EMAIL_USE_TLS'] = True
-    else:
-        conf['EMAIL_USE_SSL'] = False
 
     return conf

--- a/test_dj_email_url.py
+++ b/test_dj_email_url.py
@@ -58,6 +58,12 @@ class EmailTestSuite(unittest.TestCase):
         assert url['EMAIL_USE_SSL'] is True
         assert url['EMAIL_USE_TLS'] is False
 
+    def test_smtp_backend_without_ssl(self):
+        url = 'smtp://user@domain.com:pass@smtp.example.com:465/?ssl=False'
+        url = dj_email_url.parse(url)
+        assert url['EMAIL_USE_SSL'] is False
+        assert url['EMAIL_USE_TLS'] is False
+
     def test_smtps_backend_with_ssl(self):
         url = 'smtps://user@domain.com:pass@smtp.example.com:465/?ssl=True'
         url = dj_email_url.parse(url)
@@ -69,6 +75,12 @@ class EmailTestSuite(unittest.TestCase):
         url = dj_email_url.parse(url)
         assert url['EMAIL_USE_SSL'] is False
         assert url['EMAIL_USE_TLS'] is True
+
+    def test_smtp_backend_without_tls(self):
+        url = 'smtp://user@domain.com:pass@smtp.example.com:587/?tls=False'
+        url = dj_email_url.parse(url)
+        assert url['EMAIL_USE_SSL'] is False
+        assert url['EMAIL_USE_TLS'] is False
 
     def test_special_chars(self):
         url = 'smtp://user%21%40%23%245678:pass%25%5E%26%2A%28%29123@' \


### PR DESCRIPTION
This PR fixes the case when user sets `ssl=False` in his url.

To reproduce:
```
>>> url = 'smtp://user@domain.com:pass@smtp.example.com:465/?ssl=False'
>>> url = dj_email_url.parse(url)
>>> url['EMAIL_USE_SSL']
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
KeyError: 'EMAIL_USE_SSL'
```