### PR TITLE
 Add standard submit:// scheme, deprecate smtp/smtps.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Other option is parse an arbitrary email URL:
 
 .. code:: python
 
-    email_config = dj_email_url.parse('smtp://...')
+    email_config = dj_email_url.parse('submit://...')
 
 
 Finally, it is **necessary** to assign values to settings:
@@ -59,7 +59,7 @@ Supported backends
 
 Currently, it supports:
 
-- SMTP backend (smtp and smtps for TLS),
+- SMTP Submission backend (submit),
 
 - console backend (console),
 
@@ -69,17 +69,26 @@ Currently, it supports:
 
 - and dummy backend (dummy).
 
-SMTP backend
-------------
+SMTP Submission backend
+-----------------------
 
-The scheme ``smtps`` indicates to use TLS connections, that is to set
-``EMAIL_USE_TLS`` to ``True``.
+By default, `port 587 is used <https://www.iana.org/assignments/uri-schemes/prov/submit>`_
+and TLS is enabled, that is ``EMAIL_USE_TLS`` is set to ``True``.
 
-It is possible to specify SSL using a `ssl=True` as a query parameter:
+To disable TLS, pass `tls=False` as a query parameter:
 
 .. code:: pycon
 
-    >>> url = 'smtp://user@domain.com:pass@smtp.example.com:465/?ssl=True'
+    >>> url = 'submit://user@domain.com:pass@smtp.example.com:25/?tls=False'
+    >>> url = dj_email_url.parse(url)
+    >>> assert url['EMAIL_USE_TLS'] is False
+
+To use legacy SMTP-over-SSL (usually used with port 465), pass
+`ssl=True` as a query parameter:
+
+.. code:: pycon
+
+    >>> url = 'submit://user@domain.com:pass@smtp.example.com:465/?ssl=True'
     >>> url = dj_email_url.parse(url)
     >>> assert url['EMAIL_USE_SSL'] is True
 
@@ -91,6 +100,8 @@ in ``EMAIL_FILE_PATH`` key.
 
 Change Log
 ==========
+
+- Add standard submit:// scheme, deprecate smtp/smtps.
 
 0.0.10_ - 2016-10-14
 --------------------

--- a/test_dj_email_url.py
+++ b/test_dj_email_url.py
@@ -8,8 +8,8 @@ import dj_email_url
 
 
 class EmailTestSuite(unittest.TestCase):
-    def test_smtps_parsing(self):
-        url = 'smtps://user@domain.com:password@smtp.example.com:587'
+    def test_submit_parsing(self):
+        url = 'submit://user@domain.com:password@smtp.example.com'
         url = dj_email_url.parse(url)
 
         assert url['EMAIL_BACKEND'] == \
@@ -51,6 +51,30 @@ class EmailTestSuite(unittest.TestCase):
         assert url['EMAIL_PORT'] == 587
         assert url['EMAIL_USE_TLS'] is True
         assert url['EMAIL_USE_SSL'] is False
+
+    def test_submit_backend_with_ssl(self):
+        url = 'submit://user@domain.com:pass@smtp.example.com/?ssl=True'
+        url = dj_email_url.parse(url)
+        assert url['EMAIL_USE_SSL'] is True
+        assert url['EMAIL_USE_TLS'] is False
+
+    def test_submit_backend_without_ssl(self):
+        url = 'submit://user@domain.com:pass@smtp.example.com/?ssl=False'
+        url = dj_email_url.parse(url)
+        assert url['EMAIL_USE_SSL'] is False
+        assert url['EMAIL_USE_TLS'] is True
+
+    def test_submit_backend_with_tls(self):
+        url = 'submit://user@domain.com:pass@smtp.example.com/?tls=True'
+        url = dj_email_url.parse(url)
+        assert url['EMAIL_USE_SSL'] is False
+        assert url['EMAIL_USE_TLS'] is True
+
+    def test_submit_backend_without_tls(self):
+        url = 'submit://user@domain.com:pass@smtp.example.com/?tls=False'
+        url = dj_email_url.parse(url)
+        assert url['EMAIL_USE_SSL'] is False
+        assert url['EMAIL_USE_TLS'] is False
 
     def test_smtp_backend_with_ssl(self):
         url = 'smtp://user@domain.com:pass@smtp.example.com:465/?ssl=True'


### PR DESCRIPTION
In the [URI Scheme registry](https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml) there is the [submit](https://www.iana.org/assignments/uri-schemes/prov/submit) scheme, that is supposed to be used for email submission thru SMTP - and it defaults to the de-facto-standard port 587.

Additionaly, [SMTPS](https://en.wikipedia.org/wiki/SMTPS) is in fact the name of the SMTP-over-SSL protocol (the EMAIL_USE_SSL / 465 one), so using it for STARTTLS (EMAIL_USE_TLS / 587) - as you're doing right now - may be confusing.

That's why I think it's a good idea to deprecate old schemas, and promote submit:// in the future.