### PR TITLE
Add license file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include dj_email_url.py
 include *.rst
+include LICENSE


### PR DESCRIPTION
For the Fedora package and other distribution packages the LICENSE file has to be shipped. As the source tarball from PyPI is used to build the package in many cases should it be added.

Thanks