### PR TITLE
Cleanups

### DIFF
--- a/dj_email_url.py
+++ b/dj_email_url.py
@@ -6,14 +6,6 @@ import warnings
 import urllib.parse
 
 
-# Register email schemes in URLs.
-urllib.parse.uses_netloc.append('smtp')
-urllib.parse.uses_netloc.append('console')
-urllib.parse.uses_netloc.append('file')
-urllib.parse.uses_netloc.append('memory')
-urllib.parse.uses_netloc.append('dummy')
-
-
 DEFAULT_ENV = 'EMAIL_URL'
 
 

--- a/test_dj_email_url.py
+++ b/test_dj_email_url.py
@@ -120,7 +120,7 @@ class EmailTestSuite(unittest.TestCase):
     def test_smtp_backend_with_timeout(self):
         url = 'smtp://user@domain.com:pass@smtp.example.com:587/?timeout=10'
         url = dj_email_url.parse(url)
-        assert url['EMAIL_TIMEOUT'] is 10
+        assert url['EMAIL_TIMEOUT'] == 10
 
     def test_special_chars(self):
         url = 'smtp://user%21%40%23%245678:pass%25%5E%26%2A%28%29123@' \


### PR DESCRIPTION
I introduced a blunder in a1f57a566f081b72620e4155b3fcda8b23ea08a6 when I used `timeout is 10` instead of `timeout == 10`. Python (rightly) complains about this with `SyntaxWarning: "is" with a literal. Did you mean "=="?`

It also seems to me that extending `urllib.parse.uses_netloc` isn't necessary (anymore?). All tests still pass when removing the relevant code. I stumbled upon this because `submission` was missing from the list and it still worked and I didn't find the place where the `submission` protocol was replaced by a known protocol. Removing code is good and removing code which modifies global state is even better.

Thanks again for the package! 